### PR TITLE
improve JsonReader to wait to call JSON.parse until it reads a newline character

### DIFF
--- a/lib/jscall/main.mjs
+++ b/lib/jscall/main.mjs
@@ -295,11 +295,9 @@ class JsonReader {
     async *[Symbol.asyncIterator]() {
         for await (let data of this.stream) {
             this.acc += data
-            try {
+            if (this.acc[this.acc.length - 1] === "\n") {
                 yield JSON.parse(this.acc)
                 this.acc = ""
-            } catch {
-                // keep data in this.acc
             }
         }
         if (this.acc != "") {


### PR DESCRIPTION
The message from Ruby to JavaScript contains only one newline character at the end.
So I updated JsonReader to call JSON.parse only if it finds a newline character at the end of the data chunk.