### PR TITLE
Improve Promise handling

### DIFF
--- a/lib/jscall.rb
+++ b/lib/jscall.rb
@@ -178,7 +178,8 @@ module Jscall
         CMD_EVAL = 1
         CMD_CALL = 2
         CMD_REPLY = 3
-        CMD_ASYNC = 4
+        CMD_ASYNC_CALL = 4
+        CMD_ASYNC_EVAL = 5
 
         Param_array = 0
         Param_object = 1
@@ -283,12 +284,17 @@ module Jscall
         end
 
         def async_funcall(receiver, name, args)
-            cmd = [CMD_ASYNC, encode_obj(receiver), name, args.map {|e| encode_obj(e)}]
+            cmd = [CMD_ASYNC_CALL, encode_obj(receiver), name, args.map {|e| encode_obj(e)}]
             send_command(cmd)
         end
 
         def exec(src)
             cmd = [CMD_EVAL, src]
+            send_command(cmd)
+        end
+
+        def async_exec(src)
+            cmd = [CMD_ASYNC_EVAL, src]
             send_command(cmd)
         end
 
@@ -406,6 +412,10 @@ module Jscall
             __getpipe__.exec(src)
         end
 
+        def async_exec(src)
+            __getpipe__.async_exec(src)
+        end
+
         # name is a string object.
         # Evaluating this string in JavaScript results in a JavaScript function.
         #
@@ -431,10 +441,7 @@ module Jscall
     module AsyncInterface
         include Interface
 
-        def exec(src)
-            raise NotImplementedError, "Jscall::AsyncInterface.#exec"
-        end
-
+        alias exec async_exec
         alias funcall async_funcall
     end
 

--- a/lib/jscall.rb
+++ b/lib/jscall.rb
@@ -122,6 +122,8 @@ module Jscall
     end
 
     class AsyncRemoteRef < RemoteRef
+        alias send async_send
+
         def method_missing(name, *args)
             Jscall.__getpipe__.async_funcall(self, name, args)
         end

--- a/lib/jscall/main.mjs
+++ b/lib/jscall/main.mjs
@@ -78,6 +78,8 @@ const remoteRefHandler = new class {
     get(obj, name) {
         if (name === '__self__')
             return obj
+        else if (name === 'then')
+            return undefined
         else
             return (...args) => {
                 // this returns Promise

--- a/lib/jscall/main.mjs
+++ b/lib/jscall/main.mjs
@@ -79,6 +79,8 @@ const remoteRefHandler = new class {
         if (name === '__self__')
             return obj
         else if (name === 'then')
+            // to prevent the Promise from handling RemoteRefs as thenable
+            // e.g., `Jscall.exec("{ call: (x) => Promise.resolve(x) }").call(obj)' should return that obj itself
             return undefined
         else
             return (...args) => {

--- a/lib/jscall/main.mjs
+++ b/lib/jscall/main.mjs
@@ -3,7 +3,8 @@
 const cmd_eval = 1
 const cmd_call = 2
 const cmd_reply = 3
-const cmd_async = 4
+const cmd_async_call = 4
+const cmd_async_eval = 5
 
 const param_array = 0
 const param_object = 1
@@ -358,8 +359,12 @@ export const start = async (stdin, use_stdout) => {
             }
             else if (cmd[0] == cmd_reply)
                 returned_from_callback(cmd)
-            else if (cmd[0] == cmd_async) {
+            else if (cmd[0] == cmd_async_call) {
                 const result = funcall_from_ruby(cmd)
+                reply(result, false)
+            }
+            else if (cmd[0] == cmd_async_eval) {
+                const result = js_eval(cmd[1])
                 reply(result, false)
             }
             else

--- a/lib/jscall/main.mjs
+++ b/lib/jscall/main.mjs
@@ -298,19 +298,37 @@ const returned_from_callback = cmd => {
 class JsonReader {
     constructor(stream) {
         this.stream     = stream
-        this.acc        = ""
     }
 
     async *[Symbol.asyncIterator]() {
-        for await (let data of this.stream) {
-            this.acc += data
-            if (this.acc[this.acc.length - 1] === "\n") {
-                yield JSON.parse(this.acc)
-                this.acc = ""
+        let acc = ""
+        for await (const data of this.stream) {
+            acc += data
+            let pos = 0
+            while (true) {
+                const lineEnd = acc.indexOf("\n", pos)
+                if (lineEnd === -1) {
+                    if (pos > 0) { acc = acc.slice(pos) }
+                    break
+                }
+                const json_data = acc.slice(pos, lineEnd)
+                pos = lineEnd + 1
+                yield JSON.parse(json_data)
             }
         }
-        if (this.acc != "") {
-            yield JSON.parse(this.acc)
+        if (acc !== "") {
+            let pos = 0
+            while (true) {
+                const lineEnd = acc.indexOf("\n", pos)
+                if (lineEnd === -1) {
+                    // assert(pos < acc.length)
+                    yield acc.slice(pos, lineEnd)
+                    return
+                }
+                const json_data = acc.slice(pos, lineEnd)
+                pos = lineEnd + 1
+                yield JSON.parse(json_data)
+            }
         }
     }
 }

--- a/test/test_async_jscall.rb
+++ b/test/test_async_jscall.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "benchmark"
+require "test_helper"
+
+class TestJscall < Minitest::Test
+  def setup
+    Jscall.config
+    Jscall.config browser: false
+    define_js_functions
+  end
+
+  def define_js_functions
+    Jscall.exec <<~JS
+        function isPromise(obj) {
+            return obj instanceof Promise
+        }
+
+        function makePromise(value) {
+            return Promise.resolve({then: (resolve) => resolve(value) })
+        }
+
+        function join(value) {
+            return value
+        }
+    JS
+  end
+
+  def teardown
+    Jscall.close
+  end
+
+  def test_exec
+    ## ## not implemented yet
+    ## p1 = Jscall.async.exec('Promise.resolve(58)')
+    ## assert_equal 58, Jscall.join(p1)
+  end
+
+  def test_funcall
+    Jscall.exec <<~JS
+        let resolve = undefined
+        let fulfilled = false
+        function foo() {
+            return new Promise((res) => {
+                resolve = res
+            }).then((x) => {
+                fulfilled = true
+                return x + 1
+            })
+        }
+        function bar() {
+            return fulfilled
+        }
+        function baz(x) {
+            resolve(x + 1)
+        }
+    JS
+    p = Jscall.async.foo()
+    assert Jscall.isPromise(p)
+    assert !Jscall.bar()
+    q = Jscall.async.baz(51)
+    assert_nil q
+    r = Jscall.join(p)
+    assert_equal 53, r
+    assert Jscall.bar()
+  end
+
+  def test_promise_then
+    p = Jscall.async.makePromise(99)
+    fulfilled = false
+    q = p.async.then(proc do |x|
+        fulfilled = true
+        x + 1
+    end)
+    r = Jscall.join(q)
+    assert Jscall.isPromise(p)
+    assert Jscall.isPromise(q)
+    assert fulfilled
+    assert_equal 100, r
+  end
+
+  def test_promise_catch
+    Jscall.exec <<~JS
+        let fulfilled2 = false
+        function getFulfilled2() {
+            return fulfilled2
+        }
+        function makePromise2() {
+            new Promise((resolve, reject) => reject("test")).then((x) => {
+                fulfilled2 = true
+                return x + 1
+            })
+        }
+    JS
+    p = Jscall.async.makePromise2
+    assert Jscall.isPromise(p)
+    assert !Jscall.getFulfilled2
+    q = p.catch do |err|
+        [err, 69]
+    end
+    assert Jscall.isPromise(q)
+    r = Jscall.join(q)
+    assert !Jscall.getFulfilled2
+    assert_equal ['test', 69], r
+  end
+
+  def test_resolve_remoteref
+    obj = Object.new
+    p = Jscall.exec('({ call: (x) => Promise.resolve(x) })').async.call(obj)
+    r = Jscall.join(p)
+    assert_equal obj, r
+  end
+end

--- a/test/test_async_jscall.rb
+++ b/test/test_async_jscall.rb
@@ -34,9 +34,9 @@ class TestJscall < Minitest::Test
   end
 
   def test_exec
-    ## ## Jscall.async.exec is not implemented yet
-    ## p1 = Jscall.async.exec('Promise.resolve(58)')
-    ## assert_equal 58, Jscall.join(p1)
+    p1 = Jscall.async.exec('Promise.resolve(58)')
+    assert Jscall.isPromise(p1)
+    assert_equal 58, Jscall.join(p1)
   end
 
   def test_funcall
@@ -83,7 +83,7 @@ class TestJscall < Minitest::Test
   end
 
   def test_promise_catch
-    ## Jscall.async.exec('Promise.reject("test")').catch(proc { |err| nil })  <- this cannot prevent Node.js from aborting
+    ## Jscall.async.exec('Promise.reject("test")').catch(proc { |err| nil })  <- this .catch() cannot prevent Node.js from aborting
     Jscall.exec <<~JS
         let reject     = undefined
         let fulfilled2 = false
@@ -118,7 +118,8 @@ class TestJscall < Minitest::Test
 
   def test_resolve_remoteref
     obj = Object.new
-    p = Jscall.exec('({ call: (x) => Promise.resolve(x) })').async.call(obj)
+    p = Jscall.exec('({ call: (obj) => Promise.resolve(obj) })').async.call(obj)
+    assert Jscall.isPromise(p)
     r = Jscall.join(p)
     assert_equal obj, r
   end


### PR DESCRIPTION
- fixed AsyncRemoteRef.#then and AsyncRemoteRef.#send to return remote reference to Promise objects
    - I am wondering whether Jscall.async should return a Promise object when the callee was synchronous
- added Jscall.async to obtain Promises by calling global functions
    - Jscall.async.exec is not implemented
- added test/test_async_jscall.rb to test Jscall.async working